### PR TITLE
Add memory system to base recommender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+.ipynb_checkpoints/*
+*~
+
+pennai-dev-notebook.ipynb


### PR DESCRIPTION
Now the recommender remembers what it has recommended in the past as well as what has been previously run, and only recommends new algorithm-parameter combinations for a given dataset.

See #4 for context.