### PR TITLE
Use miniconda instead of anaconda in pennai base images ref #77

### DIFF
--- a/dockers/base/Dockerfile
+++ b/dockers/base/Dockerfile
@@ -23,19 +23,18 @@ ENV PATH /opt/node-v6.12.3-linux-x64/bin:$PATH
 # remove ssh key (it is not safe)
 # ADD files/ssh.tgz /
 
-# Anaconda 5.0.1
+# Miniconda 4.5.4
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda3-5.0.1-Linux-x86_64.sh -O ~/anaconda.sh && \
-    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
-    rm ~/anaconda.sh
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 
-# set up anaconda environment
+
+# set up conda environment
 ENV PATH /opt/conda/bin:$PATH
-RUN pip install scikit-mdr
-RUN pip install deap
 RUN pip install requests_toolbelt
 RUN pip install eli5
-RUN conda install scikit-learn pymongo tqdm
+RUN conda install --yes scikit-learn pymongo tqdm pandas matplotlib
 
 COPY files/pennai.tar.gz /opt/
 WORKDIR /opt/


### PR DESCRIPTION
- Replace Anaconda by miniconda.
- Remove `deap` and `matplotlib` since they are not used in pennai for now.
- Add pandas and matplotlib in conda installation

Related issue #77 