### PR TITLE
Release multiarch

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -7,7 +7,13 @@ services:
       context: .
       dockerfile: docker/lab/Dockerfile
       target: prod
-    image: "aliro_lab:${TAG}"
+      args:
+        - USE_WHEELS=0
+      x-bake:
+        platforms:
+          - linux/amd64
+          - linux/arm64/v8
+    image: "moorelab/aliro_lab:${TAG}"
     tty: true
     stdin_open: true
     volumes:
@@ -28,7 +34,13 @@ services:
       context: .
       dockerfile: docker/machine/Dockerfile
       target: prod
-    image: "aliro_machine:${TAG}"
+      args:
+        - USE_WHEELS=0
+      x-bake:
+        platforms:
+          - linux/amd64
+          - linux/arm64/v8
+    image: "moorelab/aliro_machine:${TAG}"
     tty: true
     stdin_open: true
     volumes:
@@ -47,7 +59,11 @@ services:
     build:
       context: .
       dockerfile: docker/dbmongo/Dockerfile
-    image: "aliro_dbmongo:${TAG}"
+      x-bake:
+        platforms:
+          - linux/amd64
+          - linux/arm64/v8
+    image: "moorelab/aliro_dbmongo:${TAG}"
     tty: true
     stdin_open: true
     ports:

--- a/release/deploy_production_release.sh
+++ b/release/deploy_production_release.sh
@@ -57,10 +57,11 @@ fi
 #########################
 
 #### push to dockerhub
-echo "Pushing to images to DockerHub"
-docker push moorelab/aliro_lab:${TAG}
-docker push moorelab/aliro_machine:${TAG}
-docker push moorelab/aliro_dbmongo:${TAG}
+echo "Images should already be pushed to DockerHub"
+# echo "Pushing to images to DockerHub"
+# docker push moorelab/aliro_lab:${TAG}
+# docker push moorelab/aliro_machine:${TAG}
+# docker push moorelab/aliro_dbmongo:${TAG}
 
 # git tag
 git tag -fa "v${TAG}" -m "v${TAG}"
@@ -69,5 +70,3 @@ git push --tags
 # create github relase and attach zip
 # TODO
 #echo "Creating Github release and pushing production zip"
-
-

--- a/release/generate_production_release.sh
+++ b/release/generate_production_release.sh
@@ -54,9 +54,11 @@ docker buildx create --name aliroreleasebuilder --driver docker-container --boos
 # build production images
 echo "Building docker production images"
 #docker volume prune
-docker-compose -f docker-compose-production.yml build -m 10g
+# docker-compose -f docker-compose-production.yml build -m 10g
+docker buildx bake -f docker-compose-production.yml --push
 
-echo "Tagging production images"
-docker tag aliro_lab:${TAG} moorelab/aliro_lab:${TAG}
-docker tag aliro_machine:${TAG} moorelab/aliro_machine:${TAG}
-docker tag aliro_dbmongo:${TAG} moorelab/aliro_dbmongo:${TAG}
+# tagging production images is not necessary with docker buildx bake
+# echo "Tagging production images"
+# docker tag aliro_lab:${TAG} moorelab/aliro_lab:${TAG}
+# docker tag aliro_machine:${TAG} moorelab/aliro_machine:${TAG}
+# docker tag aliro_dbmongo:${TAG} moorelab/aliro_dbmongo:${TAG}

--- a/release/generate_production_release.sh
+++ b/release/generate_production_release.sh
@@ -37,6 +37,20 @@ cp release/docker-compose-hub-image.yml "${PROD_BUILD_DIR}/docker-compose.yml"
 
 zip -r $PROD_ZIP_FILENAME $PROD_BUILD_DIR
 
+# build multi-architecture images with buildx
+echo "Installing multi-platform installation support"
+docker run --privileged -rm tonistiigi/binfmt --install all
+
+# create an aliro release builder with buildx
+docker buildx create --name aliroreleasebuilder --driver docker-container --boostrap --use
+
+##### NOTES #######
+# Alternatively, I should be able to use the --builder flag, for example docker buildx bake --builder aliroreleasebuilder
+# This may be a better option if it works, since this won't change the builder in the current shell.
+# The default builder will remain selected, and the aliroreleasebuilder will be used only by this command.
+# For completeness, the documentation mentions the BUILDX_BUILDER env variable also:
+# https://docs.docker.com/build/builders/
+
 # build production images
 echo "Building docker production images"
 #docker volume prune


### PR DESCRIPTION
The updated shell scripts will work with `docker buildx bake` instead of `docker compose` to deploy amd64 and arm64 versions of docker images.