### PR TITLE
Delete datasets bug fixes and integration test

### DIFF
--- a/.env
+++ b/.env
@@ -7,5 +7,5 @@
 #   Leave this set to 0 on the GitHub repo so the unit and 
 #      integration tests do not need to have wheels (until we 
 #      find a convenient way to use wheels on GitHub)
-TAG=0.20
+TAG=0.21a0
 USE_WHEELS=1

--- a/lab/lab.js
+++ b/lab/lab.js
@@ -640,8 +640,10 @@ app.delete('/api/v1/datasets/:id', async (req, res, next) => {
             return res.status(404).send({ message: 'dataset ' + req.params.id + ' not found'});
         }
 
-        if (dataset.ai && (dataset.ai.status == recommenderStatus.RUNNING || dataset.ai.status == recommenderStatus.INITIALIZING)) {
-            return res.status(409).send({message: 'cannot delete dataset, recommender running'});
+        // if (dataset.ai && (dataset.ai.status == recommenderStatus.RUNNING || dataset.ai.status == recommenderStatus.INITIALIZING)) {
+        if (dataset.ai && ['on', 'requested'].some(status => dataset.ai.status === status)) {
+            console.log('cannot delete dataset, AI is enabled');
+            return res.status(409).send({message: 'cannot delete dataset, AI is enabled'});
         }
         
         const dataset_file_id = db.toObjectID(dataset.files[0]._id);
@@ -654,9 +656,11 @@ app.delete('/api/v1/datasets/:id', async (req, res, next) => {
         ]}
 
         let experiments = await db.experiments.find(query).toArrayAsync();
-        let runningExp = experiments.find(exp => exp._status.includes('running', 'pending', 'suggested'));
+        console.log(experiments);
+        let runningExp = experiments.find(exp => ['running', 'pending', 'suggested'].some(status => exp._status === status));
 
         if (runningExp) {
+            console.log('cannot delete dataset, experiments running');
             return res.status(409).send({message: 'cannot delete dataset, experiments running'});
         }
 

--- a/lab/lab.js
+++ b/lab/lab.js
@@ -654,7 +654,7 @@ app.delete('/api/v1/datasets/:id', async (req, res, next) => {
         ]}
 
         let experiments = await db.experiments.find(query).toArrayAsync();
-        let runningExp = experiments.find(exp => exp._status == 'running');
+        let runningExp = experiments.find(exp => exp._status.includes('running', 'pending', 'suggested'));
 
         if (runningExp) {
             return res.status(409).send({message: 'cannot delete dataset, experiments running'});


### PR DESCRIPTION
Updated the datasets `DELETE` endpoint to check the status of the ai and if experiments are running before attempting to delete a dataset.
Added an integration test to validate this works as expected.